### PR TITLE
#2 Actuator 테스트 과정에서 발견된 문제 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'io.github.lazydx'
-version = '1.1.1'
+version = '1.1.2'
 
 java {
     toolchain {
@@ -35,11 +35,16 @@ dependencies {
     
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator'
+    testImplementation 'io.micrometer:micrometer-registry-prometheus'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+processResources {
+    expand(project.properties)
 }
 
 jar {

--- a/src/main/java/com/ldx/webstarter/infrastructure/advice/ResponseAdvice.java
+++ b/src/main/java/com/ldx/webstarter/infrastructure/advice/ResponseAdvice.java
@@ -77,7 +77,7 @@ public class ResponseAdvice implements ResponseBodyAdvice<Object> {
             logger.debug("Skipping - ByteArrayHttpMessageConverter");
             return false;
         }
-        
+
         // Resource 타입(파일 다운로드)은 건너뜀
         if (Resource.class.isAssignableFrom(returnType.getParameterType())) {
             logger.debug("Skipping - Resource type (file download)");
@@ -95,7 +95,7 @@ public class ResponseAdvice implements ResponseBodyAdvice<Object> {
         
         // Actuator 엔드포인트는 건너뜀
         String declaringClassName = returnType.getDeclaringClass().getName();
-        if (declaringClassName.startsWith("org.springframework.boot.actuator") ||
+        if (declaringClassName.startsWith("org.springframework.boot.actuate") ||
             declaringClassName.contains("HealthEndpoint") ||
             declaringClassName.contains("InfoEndpoint")) {
             logger.debug("Skipping - actuator endpoint: {}", declaringClassName);

--- a/src/main/java/com/ldx/webstarter/infrastructure/advice/ResponseAdvice.java
+++ b/src/main/java/com/ldx/webstarter/infrastructure/advice/ResponseAdvice.java
@@ -57,10 +57,24 @@ public class ResponseAdvice implements ResponseBodyAdvice<Object> {
             logger.debug("Skipping - returnType is null");
             return false;
         }
+
+        Class<?> type = returnType.getParameterType();
         
         // 이미 ApiResponse 타입이면 건너뜀
         if (returnType.getParameterType().equals(ApiResponse.class)) {
             logger.debug("Skipping - already ApiResponse type");
+            return false;
+        }
+
+        // 바이너리 데이터(byte[])는 건너뜀
+        if (type.equals(byte[].class)) {
+            logger.debug("Skipping - type is byte");
+            return false;
+        }
+
+        // ByteArrayConverter가 사용되는 경우 건너뜀
+        if (converterType != null && converterType.getSimpleName().contains("ByteArrayHttpMessageConverter")) {
+            logger.debug("Skipping - ByteArrayHttpMessageConverter");
             return false;
         }
         

--- a/src/main/java/com/ldx/webstarter/infrastructure/autoconfigure/WebStarterAutoConfiguration.java
+++ b/src/main/java/com/ldx/webstarter/infrastructure/autoconfigure/WebStarterAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.Ordered;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -30,6 +31,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import jakarta.annotation.PostConstruct;
 import java.util.List;
+import java.util.Properties;
 
 /**
  * Web Starter 메인 자동 설정 클래스.
@@ -84,10 +86,24 @@ public class WebStarterAutoConfiguration {
      */
     @PostConstruct
     public void init() {
+        String version = "DEV"; // 기본값
+        try {
+            Properties props = new Properties();
+            // build.gradle에서 생성된 version.properties 파일 로드
+            props.load(new ClassPathResource("version.properties").getInputStream());
+            version = props.getProperty("version", version);
+        } catch (Exception e) {
+            // 속성 파일을 찾지 못한 경우, MANIFEST.MF에서 다시 시도 (운영 환경)
+            String manifestVersion = getClass().getPackage().getImplementationVersion();
+            if (manifestVersion != null) {
+                version = manifestVersion;
+            }
+        }
+
         // 헤더
         logger.info("╔═══════════════════════════════════════════════════════════════╗");
         logger.info("║                 🚀 LDX WEB STARTER                            ║");
-        logger.info("║                    Version 1.1.0                               ║");
+        logger.info(String.format("║                    Version %-35s ║", version));
         logger.info("╚═══════════════════════════════════════════════════════════════╝");
         
         // 설정 상태
@@ -135,9 +151,9 @@ public class WebStarterAutoConfiguration {
                 if (!properties.isResponseEnabled()) {
                     return;
                 }
-                
+
                 logger.debug("Configuring HttpMessageConverter order for ResponseAdvice compatibility");
-                
+
                 // StringHttpMessageConverter를 찾아서 제거
                 HttpMessageConverter<?> stringConverter = null;
                 for (int i = 0; i < converters.size(); i++) {
@@ -146,7 +162,7 @@ public class WebStarterAutoConfiguration {
                         break;
                     }
                 }
-                
+
                 // MappingJackson2HttpMessageConverter 뒤에 StringHttpMessageConverter 추가
                 if (stringConverter != null) {
                     boolean jacksonFound = false;
@@ -157,7 +173,7 @@ public class WebStarterAutoConfiguration {
                             break;
                         }
                     }
-                    
+
                     // Jackson 컨버터가 없으면 마지막에 추가
                     if (!jacksonFound) {
                         converters.add(stringConverter);

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${version}

--- a/src/test/java/com/ldx/webstarter/integration/ResponseWrapperIntegrationTest.java
+++ b/src/test/java/com/ldx/webstarter/integration/ResponseWrapperIntegrationTest.java
@@ -1,10 +1,14 @@
 package com.ldx.webstarter.integration;
 
 
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+
+
 import com.ldx.webstarter.infrastructure.autoconfigure.WebStarterAutoConfiguration;
 import com.ldx.webstarter.response.ApiResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -14,8 +18,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Response Wrapper 통합 테스트
@@ -23,13 +31,16 @@ import static org.hamcrest.Matchers.*;
  * API 응답이 자동으로 ApiResponse로 래핑되는지 검증합니다.
  */
 @SpringBootTest(classes = {
+    WebMvcAutoConfiguration.class,
     WebStarterAutoConfiguration.class,
+    JacksonAutoConfiguration.class,
     ResponseWrapperIntegrationTest.TestController.class
 })
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
     "web-starter.enabled=true",
-    "web-starter.response-toggle.enabled=true"
+    "web-starter.response-toggle.enabled=true",
+    "management.endpoints.web.exposure.include=health,prometheus"
 })
 class ResponseWrapperIntegrationTest {
     
@@ -91,7 +102,18 @@ class ResponseWrapperIntegrationTest {
             // 이중 래핑되지 않았는지 확인
             .andExpect(jsonPath("$.data.success").doesNotExist());
     }
-    
+
+    @Test
+    void binaryResponse_shouldNotBeWrapped() throws Exception {
+        // byte[] 응답은 ApiResponse로 래핑되지 않고, 원본 데이터가 그대로 반환되어야 함
+        mockMvc.perform(get("/test/binary"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_OCTET_STREAM))
+                .andExpect(content().bytes("binary data".getBytes()))
+                // ApiResponse로 래핑되지 않았는지 확인
+                .andExpect(content().string(not(containsString("success"))));
+    }
+
     /**
      * 테스트용 컨트롤러
      */
@@ -121,6 +143,11 @@ class ResponseWrapperIntegrationTest {
         @GetMapping("/test/already-wrapped")
         public ApiResponse<String> alreadyWrappedResponse() {
             return ApiResponse.success("Already wrapped");
+        }
+
+        @GetMapping("/test/binary")
+        public byte[] binaryResponse() {
+            return "binary data".getBytes();
         }
         
         static class TestUser {


### PR DESCRIPTION
### 변경 목적

   -   `/actuator/prometheus` 엔드포인트 테스트 과정에서 발견된 `web-starter`의 잠재적 문제점들을 해결하고, 테스트 환경을 안정화하여 향 후 확장성을 높이고자 함.

   ### 주요 변경 및 개선 사항

   1.  **응답 래핑(Response Wrapping) 동작 개선**
       -   **문제**: `ResponseAdvice`가 `byte[]` 타입의 응답까지 JSON으로 래핑하여, Prometheus(`text/plain`) 같은 비-JSON 응답 시 데이터
   손상될 수 있는 잠재적 위험 발견.
       -   **조치**: `ResponseAdvice`가 `byte[]` 타입을 명시적으로 제외하도록 수정하고, 검증 테스트 추가.

   2.  **통합 테스트 환경 안정화**
       -   **문제**: 테스트 컨텍스트에 `WebMvcAutoConfiguration` 등 핵심 설정이 누락되어, Actuator 엔드포인트가 노출되지 않는 등 실제   
   환경과 다르게 동작.
       -   **조치**: `@SpringBootTest`에 `WebMvcAutoConfiguration` 등 필수 자동 설정을 명시적으로 추가하여 테스트 환경 신뢰성 확보.     

   3.  **개발 편의성 개선: 동적 버전 로깅**
       -   **개선**: 애플리케이션 시작 배너에 `build.gradle`의 실제 버전이 표시되도록 수정.
       -   **방식**: Gradle `processResources`와 `version.properties` 파일을 연동하여 구현.

   ### 기대 효과

   -   Prometheus 등 `text/plain` 기반의 Actuator 엔드포인트를 사용하더라도 응답이 손상되지 않도록 보장.
   -   `web-starter`의 통합 테스트 환경 안정화 및 신뢰도 향상.
   -   시작 로그에서 명확한 버전 확인 가능.

resolved #2 
